### PR TITLE
debugging.md: Fix a markdown syntax problem

### DIFF
--- a/debugging.md
+++ b/debugging.md
@@ -467,7 +467,7 @@ See also: [RR](#rr), [WinDbg - Time Travel Debugging](https://github.com/MattPD/
 	+ Building a Flexible Hypervisor-Level Debugger
 		- Insomni'hack 2019; Mathieu Tarral
 		- https://drive.google.com/open?id=1ZMUszfwWDOljdDfPOJgkEfSabNy0UAJR
-‏* QIRA - QEMU Interactive Runtime Analyser
+* QIRA - QEMU Interactive Runtime Analyser
 	+ http://qira.me/
 	+ https://github.com/BinaryAnalysisPlatform/qira/
 * Radare2


### PR DESCRIPTION
The diff looks weird, but ctrl-f for "qira" on https://github.com/MattPD/cpplinks/blob/master/debugging.md#software . Maybe some non-ascii char or something?